### PR TITLE
Use a 32-bit color so save the .png

### DIFF
--- a/Resizetizer.NT/SkiaSharpSvgTools.cs
+++ b/Resizetizer.NT/SkiaSharpSvgTools.cs
@@ -105,7 +105,7 @@ namespace Resizetizer
 
 			using (var stream = File.OpenWrite(destination))
 			{
-				svg.Picture.ToImage(stream, SKColors.Empty, SKEncodedImageFormat.Png, 100, (float)adjustRatio, (float)adjustRatio, SKColorType.Argb4444, SKAlphaType.Premul);
+				svg.Picture.ToImage(stream, SKColors.Empty, SKEncodedImageFormat.Png, 100, (float)adjustRatio, (float)adjustRatio, SKColorType.Rgba8888, SKAlphaType.Premul);
 			}
 
 			sw.Stop();


### PR DESCRIPTION
Make sure to use the larger color size to save to improve the gradient.

> https://docs.microsoft.com/dotnet/api/SkiaSharp.SKColorType
> - `Argb4444` is 16-bit
> - `Rgba8888` is 32-bit

This PR fixes #4