### PR TITLE
List replaced with ConcurrentBag

### DIFF
--- a/Resizetizer.NT/ResizetizeSharedImages.cs
+++ b/Resizetizer.NT/ResizetizeSharedImages.cs
@@ -3,6 +3,7 @@ using Microsoft.Build.Utilities;
 //using SixLabors.ImageSharp;
 //using SixLabors.ImageSharp.Processing;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -63,7 +64,7 @@ namespace Resizetizer
 
 			var originalScaleDpi = DpiPath.GetOriginal(PlatformType);
 
-			var resizedImages = new List<ResizedImageInfo>();
+			var resizedImages = new ConcurrentBag<ResizedImageInfo>();
 
 			System.Threading.Tasks.Parallel.ForEach(images, img =>
 			{


### PR DESCRIPTION
To fix the issue https://github.com/Redth/ResizetizerNT/issues/8 
After a few tests I noticed that the result [list contains null elements](https://github.com/Redth/ResizetizerNT/issues/8#issuecomment-695344865). 
At first, I checked all the results from `Resizer.Resize` and `Resizer.CopyFile` in the method `DoExecute`, but there weren't any null ones. 

It's weird bug, I spend a lot of time trying to avoid it in my projects. Hope this help. 
