### PR TITLE
Improve the downscaling of vectors

### DIFF
--- a/Resizetizer.NT.Tests/SkiaSharpAppIconToolsTests.cs
+++ b/Resizetizer.NT.Tests/SkiaSharpAppIconToolsTests.cs
@@ -35,12 +35,14 @@ namespace Resizetizer.NT.Tests
 			[InlineData(2, 0.5, "appicon.svg", "appiconfg.svg")]
 			[InlineData(2, 1, "appicon.svg", "appiconfg.svg")]
 			[InlineData(2, 2, "appicon.svg", "appiconfg.svg")]
+			[InlineData(3, 3, "appicon.svg", "appiconfg.svg")]
 			// scary increments
 			[InlineData(0.3, 0.3, "appicon.svg", "appiconfg.svg")]
 			[InlineData(0.3, 0.7, "appicon.svg", "appiconfg.svg")]
 			[InlineData(0.7, 0.7, "appicon.svg", "appiconfg.svg")]
 			[InlineData(1, 0.7, "appicon.svg", "appiconfg.svg")]
 			[InlineData(2, 0.7, "appicon.svg", "appiconfg.svg")]
+			[InlineData(2.3, 2.3, "appicon.svg", "appiconfg.svg")]
 			[InlineData(0.3, 1, "appicon.svg", "appiconfg.svg")]
 			[InlineData(0.3, 2, "appicon.svg", "appiconfg.svg")]
 			// scary increments

--- a/Resizetizer.NT/Resizetizer.NT.csproj
+++ b/Resizetizer.NT/Resizetizer.NT.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>8.0</LangVersion>
 
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 

--- a/Resizetizer.NT/SharedImageInfo.cs
+++ b/Resizetizer.NT/SharedImageInfo.cs
@@ -1,5 +1,4 @@
-﻿//using SixLabors.ImageSharp;
-//using SixLabors.ImageSharp.Processing;
+﻿using System;
 using System.Drawing;
 using System.IO;
 
@@ -15,16 +14,17 @@ namespace Resizetizer
 
 		public Color? TintColor { get; set; }
 
-		public bool IsVector
-			=> Path.GetExtension(Filename)?.TrimStart('.')?.ToLowerInvariant()?.Equals("svg") ?? false;
+		public bool IsVector => IsVectorFilename(Filename);
 
 		public bool IsAppIcon { get; set; }
 
 		public string ForegroundFilename { get; set; }
 
-		public bool ForegroundIsVector
-			=> Path.GetExtension(ForegroundFilename)?.TrimStart('.')?.ToLowerInvariant()?.Equals("svg") ?? false;
+		public bool ForegroundIsVector => IsVectorFilename(ForegroundFilename);
 
 		public double ForegroundScale { get; set; } = 1.0;
+
+		private static bool IsVectorFilename(string filename)
+			=> Path.GetExtension(filename)?.Equals(".svg", StringComparison.OrdinalIgnoreCase) ?? false;
 	}
 }

--- a/Resizetizer.NT/SkiaSharpAppIconTools.cs
+++ b/Resizetizer.NT/SkiaSharpAppIconTools.cs
@@ -58,7 +58,7 @@ namespace Resizetizer
 					canvas.Save();
 					canvas.Scale(bgScale, bgScale);
 
-					backgroundTools.DrawUnscaled(canvas);
+					backgroundTools.DrawUnscaled(canvas, bgScale);
 					canvas.Restore();
 
 					if (hasForeground)
@@ -89,20 +89,17 @@ namespace Resizetizer
 
 						// scale so the forground is the same size as the background
 						canvas.Scale(fgScale, fgScale);
-						
+
 						// scale to the user scale, centering
 						canvas.Scale(userFgScale, userFgScale, fgScaledSizeCenterX, fgScaledSizeCenterY);
 
-						foregroundTools.DrawUnscaled(canvas);
+						foregroundTools.DrawUnscaled(canvas, fgScale * userFgScale);
 					}
 				}
 
 				// Save (encode)
-				using (var pixmap = tempBitmap.PeekPixels())
-				using (var wrapper = new SKFileWStream(destination))
-				{
-					pixmap.Encode(wrapper, SKPngEncoderOptions.Default);
-				}
+				using var wrapper = File.Create(destination);
+				tempBitmap.Encode(wrapper, SKEncodedImageFormat.Png, 100);
 			}
 
 			sw.Stop();

--- a/Resizetizer.NT/SkiaSharpBitmapTools.cs
+++ b/Resizetizer.NT/SkiaSharpBitmapTools.cs
@@ -29,7 +29,7 @@ namespace Resizetizer
 		public override SKSize GetOriginalSize() =>
 			bmp.Info.Size;
 
-		public override void DrawUnscaled(SKCanvas canvas) =>
+		public override void DrawUnscaled(SKCanvas canvas, float scale) =>
 			canvas.DrawBitmap(bmp, 0, 0, Paint);
 
 		public void Dispose()


### PR DESCRIPTION
When some vectors are downscaled using numbers that result in floating-point coordinates, the resulting image looks bad. This attempts to avoid that by using raster scaling.

| Original | New |
| :--: | :--: |
| ![original](https://user-images.githubusercontent.com/1096616/105367513-31820e00-5c09-11eb-8906-9e7693426b8b.png) | ![output-0 3-0 3-appicon svg-appiconfg svg](https://user-images.githubusercontent.com/1096616/105367536-3646c200-5c09-11eb-985a-9a91d44212bc.png) |


And when scaled at 1x (no scaling)
![output-1-1-appicon svg-appiconfg svg](https://user-images.githubusercontent.com/1096616/105367729-6c844180-5c09-11eb-9b34-de78aff702ad.png)

