### PR TITLE
feat: Mark package as developmentDependency

### DIFF
--- a/Resizetizer.NT/Resizetizer.NT.csproj
+++ b/Resizetizer.NT/Resizetizer.NT.csproj
@@ -22,6 +22,7 @@
 		<PackageOutputPath>..\output</PackageOutputPath>
 		<IncludeBuildOutput>False</IncludeBuildOutput>
 		<NoWarn>NU5100;NU5128</NoWarn>
+		<DevelopmentDependency>true</DevelopmentDependency>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Allow  automatically set PrivateAssets to All when ResizetizerNT package added

fixes #70 