### PR TITLE
Use item alias to check for invalid file names

### DIFF
--- a/Resizetizer.NT.Tests/DetectInvalidResourceOutputFilenamesTests.cs
+++ b/Resizetizer.NT.Tests/DetectInvalidResourceOutputFilenamesTests.cs
@@ -82,6 +82,19 @@ namespace Resizetizer.NT.Tests
 				AssertInvalidFilename(task, i);
 				Assert.False(success);
 			}
+			
+			[Fact]
+			public void ValidFileWithAliasSucceeds()
+			{
+				var i = new TaskItem("images/appiconfg-red-512.svg");
+				i.SetMetadata("Link", "appiconfg_red.png");
+				var task = GetNewTask(i);
+
+				var success = task.Execute();
+
+				AssertValidFilename(task, i);
+				Assert.True(success);
+			}
 		}
 	}
 }

--- a/Resizetizer.NT/DetectInvalidResourceOutputFilenamesTask.cs
+++ b/Resizetizer.NT/DetectInvalidResourceOutputFilenamesTask.cs
@@ -33,8 +33,12 @@ namespace Resizetizer
 					System.Threading.Tasks.Parallel.ForEach(Items, item =>
 					{
 						var filename = item.ItemSpec;
+						var alias = item.GetMetadata("Link");
+						var outputName = string.IsNullOrWhiteSpace(alias)
+							? filename
+							: alias;
 
-						if (!Utils.IsValidResourceFilename(filename) || ! File.Exists(filename))
+						if (!Utils.IsValidResourceFilename(outputName) || ! File.Exists(filename))
 							invalidFilenames.Add(filename);
 					});
 				}


### PR DESCRIPTION
The changes done on #55 that adds the ability to define an alias for an item did update the validation on `SharedImageInfo.cs` to use its `OutputName` (where the `OutputName` is the `Alias` if defined otherwise the `Filename`). 

Then the changes on #56 move that validation to `Utils.cs` where we just check item filename.

This is a simple "quick fix" to resolve the situation where the alias is a valid filename. (as it's the `OutputName` that will be used to generate the final filename, right ?)
